### PR TITLE
Changes to DNF upgrades and added Variable to turn of unattended reboot

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Available variables are listed below, along with default values (see `defaults/m
 
 Set packages which you don't want to upgrade automatically on hold before upgrading.
 
+    upgrade_unattended_reboot: "true"
+Default is true, set to false if you do not want to reboot automatically after installing updates which require reboot.
+
 ## Dependencies
 
 None.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 upgrade_packages_on_hold: []
+upgrade_unattended_reboot: "true"

--- a/tasks/dnf.yml
+++ b/tasks/dnf.yml
@@ -23,11 +23,17 @@
     state: absent
   with_items: "{{ upgrade_packages_on_hold }}"
 
+- name: Install the latest version of dnf-utils
+  dnf:
+    name: dnf-utils
+    state: latest
+
 - name: Check for reboot hint.
-  shell: needs-restarting
+  shell: dnf needs-restarting -r
   register: reboot_hint_dnf
+  failed_when: reboot_hint_dnf.rc >= 2
 
 - name: Set Reboot Hint.
   set_fact:
     reboot_hint: true
-  when: reboot_hint_dnf.stdout != ""
+  when: reboot_hint_dnf.rc == 1

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,7 +7,9 @@
   shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
   async: 1
   poll: 0
-  when: reboot_hint is defined and reboot_hint
+  when: 
+    - reboot_hint is defined and reboot_hint 
+    - upgrade_unattended_reboot
 
 - name: Wait for server to restart.
   local_action:


### PR DESCRIPTION
Added upgrade_unattended_reboot variable to disable unattended reboot, default is true.

Added install package dnf-utils if not installed yet, to be sure to execute dnf needs-restarting -r.
Changed failed_when condition to include retun code 0 and 1.
Changed Reboot Hint to set when return code equals 1.

Added to check for unattended_reboot is true before rebooting.

Updated README.md and explained upgrade_unattended_reboot variable.
