### PR TITLE
Fix ansible-lint errors

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,16 +14,16 @@
   shell: 'sleep 1 && shutdown -r now "Reboot triggered by Ansible" && sleep 1'
   async: 1
   poll: 0
-  when: 
+  when:
     - ((reboot_hint is defined and reboot_hint | bool) and (upgrade_unattended_reboot | bool)) or (upgrade_force_reboot | bool)
 
 - name: Wait for server to restart.
-  local_action:
-    module: wait_for
-      host={{ inventory_hostname }}
-      port=22
-      delay=10
-      timeout=300
+  module: wait_for
+    host={{ inventory_hostname }}
+    port=22
+    delay=10
+    timeout=300
   become: false
+  delegate_to: localhost
   when:
     - ((reboot_hint is defined and reboot_hint | bool) and (upgrade_unattended_reboot | bool)) or (upgrade_force_reboot | bool)


### PR DESCRIPTION
```
find ./ -name '*.yml' -exec $SHELL -c 'ansible-lint "$0" -x 204,602' {} \;

[201] Trailing whitespace
tasks/main.yml:17
  when: 

[504] Do not use 'local_action', use 'delegate_to: localhost'
tasks/main.yml:21
  local_action:
```